### PR TITLE
Fix build for both architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: DOCKER_HUB
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
 
     steps:
 
@@ -23,7 +18,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -54,9 +49,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I found out that the last build overwrite the first one. I copied over how we are doing it in plone-backend, updated some versions of GitHub actions.


<img width="582" alt="image" src="https://user-images.githubusercontent.com/486927/194534091-6316f19d-f78c-4bb2-b589-2e99bc641dde.png">
