### PR TITLE
Remove cache, omelette and .yarn/cache folders of final image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .vscode
+.*project
+.settings/
 
 # pyenv
 .python-version

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN yo @plone/volto \
 
 RUN cd plone-frontend \
     && yarn install --network-timeout 1000000 \
-    && yarn build
+    && yarn build \
+    && rm -rf cache omelette .yarn/cache
 
 FROM base
 LABEL maintainer="Plone Community <dev@plone.org>" \

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -18,7 +18,8 @@ RUN curl -k -L -o workspace.zip https://github.com/plone/volto/archive/refs/head
 
 RUN cd plone-frontend \
     && yarn install --network-timeout 1000000 \
-    && yarn build
+    && yarn build \
+    && rm -rf cache omelette .yarn/cache
 
 FROM base
 LABEL maintainer="Plone Community <dev@plone.org>" \


### PR DESCRIPTION
This folder is not needed to run Volto.

fixes #28