### PR TITLE
Fix pnpm on runtime

### DIFF
--- a/pnpm/Dockerfile.prod
+++ b/pnpm/Dockerfile.prod
@@ -25,7 +25,10 @@ USER node
 
 # Set working directory to /app
 WORKDIR /app
-RUN corepack use pnpm@9
+# Upgrades pnpm to the latest version globally
+RUN corepack install -g pnpm
+# Specifically install and uses the package manager configured in the local project
+RUN corepack install
 
 # Expose default Express port
 EXPOSE 3000


### PR DESCRIPTION
@ericof This will fix the problem that pnpm tries to download on runtime.

However, it has a flaw, because if anybody updates the packageManager key in the project (eg. it's not in sync with Volto's), it will fail again in containers without outside access.

So somehow we have to change the `Dockerfile` in apps as well :( Let's talk when you are around.