### PR TITLE
Remove redundant corepack pnpm version specification

### DIFF
--- a/pnpm/Dockerfile.prod
+++ b/pnpm/Dockerfile.prod
@@ -25,7 +25,6 @@ USER node
 
 # Set working directory to /app
 WORKDIR /app
-RUN corepack use pnpm@9
 
 # Expose default Express port
 EXPOSE 3000


### PR DESCRIPTION
The `corepack use pnpm@9` command is unnecessary since corepack is already enabled and will automatically detect and use the appropriate pnpm version based on the project configuration. This change simplifies the Dockerfile and maintains consistency with other Docker images in the project.

I was going to upgrade to pnpm 10. But I saw that it wasn't necessary, and the only reference to pnpm 9 is there.

Ref: https://github.com/plone/volto/pull/7239