### PR TITLE
19.x: Make sure pnpm won't need to be installed at runtime

### DIFF
--- a/pnpm/Dockerfile
+++ b/pnpm/Dockerfile
@@ -20,3 +20,6 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 
 # Copy Volto project
 COPY --from=builder /app/ /app/
+
+# Make sure the correct version of pnpm from package.json is installed
+RUN corepack install

--- a/pnpm/Dockerfile.prod
+++ b/pnpm/Dockerfile.prod
@@ -25,7 +25,6 @@ USER node
 
 # Set working directory to /app
 WORKDIR /app
-RUN corepack use pnpm@9
 
 # Expose default Express port
 EXPOSE 3000


### PR DESCRIPTION
Make sure we install pnpm in the final image _after_ we have the package.json that tells us which specific version to use. Otherwise we end up with a different version in the image, and the right one gets fetched at runtime.

I will also prepare a backport for 18.x, but there I'll leave the installation of pnpm@9 in the prod-config image just in case someone is using it without a package.json that pins pnpm.

This is based on @wesleybl's PR #57 and fixes #59