### PR TITLE
18.x: Make sure pnpm won't need to be installed at runtime

### DIFF
--- a/pnpm/Dockerfile
+++ b/pnpm/Dockerfile
@@ -20,3 +20,6 @@ LABEL maintainer="Plone Community <dev@plone.org>" \
 
 # Copy Volto project
 COPY --from=builder /app/ /app/
+
+# Make sure the correct version of pnpm from package.json is installed
+RUN corepack install


### PR DESCRIPTION
Backport of #63, but a bit more careful to keep the current behavior of the prod-config image.