### PR TITLE
Use the /ok route in the production healthcheck

### DIFF
--- a/pnpm/Dockerfile.prod
+++ b/pnpm/Dockerfile.prod
@@ -18,7 +18,10 @@ RUN <<EOT
     chown -R node:node /app
 EOT
 
-RUN npm i -g corepack@latest && corepack enable
+RUN <<EOT
+    set -e
+    npm i -g corepack@latest && corepack enable
+EOT
 
 # Run the image with user node
 USER node
@@ -30,7 +33,7 @@ WORKDIR /app
 EXPOSE 3000
 
 # Set healthcheck to port 3000
-HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=3000 ; wget -q http://127.0.0.1:"$LISTEN_PORT" -O - || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s CMD [ -n "$LISTEN_PORT" ] || LISTEN_PORT=3000 ; wget -q http://127.0.0.1:"$LISTEN_PORT"/ok -O - || exit 1
 
 # Entrypoint would be pnpm
 ENTRYPOINT [ "pnpm" ]


### PR DESCRIPTION
## What

Point the production healthcheck in `pnpm/Dockerfile.prod` at Volto's `/ok` liveness route instead of the site root.

## Why

The healthcheck previously fetched `/`, which renders the Plone Site root. That coupled the container's health to backend state and permissions rather than to the frontend process itself. The check reported **unhealthy** whenever:

- the backend was unreachable (not yet up, restarting, or misconfigured), or
- the Plone Site view permission blocked anonymous access (non-2xx on `/`).

In both cases the Volto/Express process was running fine, yet the container was marked unhealthy — causing false failures and unwanted orchestrator restarts.

`/ok` is served directly by the frontend and returns `200 OK` without proxying to the backend, so the healthcheck now reflects the actual state of the frontend process.

## Changes

- Healthcheck now requests `http://127.0.0.1:$LISTEN_PORT/ok`.
- Minor: wrapped the `corepack` install in a heredoc `RUN` for consistency with the busybox block above (no functional change).

Closes #78